### PR TITLE
Feature: Add `dry-run` option to `metadata` and `weather` sub-commands

### DIFF
--- a/commands/metadata/catalog.js
+++ b/commands/metadata/catalog.js
@@ -5,7 +5,7 @@ import ora from 'ora';
 import { buildWeatherLinkApiUrl, checkForRequired } from '../../lib/utils.js';
 
 export default (options) => {
-  const spinner = !options.raw ? ora('Retrieving Sensor Catalog').start() : undefined;
+  const spinner = !options.raw && !options.dryRun ? ora('Retrieving Sensor Catalog').start() : undefined;
 
   const envVars = checkForRequired(["WEATHER_LINK_API_KEY", "WEATHER_LINK_API_SECRET", "WEATHER_LINK_BASE_API_URL"])
   if (!envVars.exist) {
@@ -18,13 +18,17 @@ export default (options) => {
 
   const API_KEY = process.env.WEATHER_LINK_API_KEY;
 
-  axios.get(
-    buildWeatherLinkApiUrl(
-      `sensor-catalog`,
-      { "api-key": API_KEY, "t": String(Math.round(Date.now() / 1000)) },
-      { "api-key": API_KEY, "t": String(Math.round(Date.now() / 1000)) }
-    )
-  )
+  const urlToQuery = buildWeatherLinkApiUrl(
+    `sensor-catalog`,
+    { "api-key": API_KEY, "t": String(Math.round(Date.now() / 1000)) },
+    { "api-key": API_KEY, "t": String(Math.round(Date.now() / 1000)) }
+  );
+
+  if (options.dryRun) {
+    return console.log(urlToQuery);
+  }
+
+  axios.get(urlToQuery)
     .then((response) => {
       if (options.raw) {
         return console.log(JSON.stringify(response.data));

--- a/commands/metadata/mine.js
+++ b/commands/metadata/mine.js
@@ -5,7 +5,7 @@ import ora from 'ora';
 import { buildWeatherLinkApiUrl, checkForRequired } from '../../lib/utils.js';
 
 export default (options) => {
-  const spinner = !options.raw ? ora('Searching for Stations').start() : undefined;
+  const spinner = !options.raw && !options.dryRun ? ora('Searching for Stations').start() : undefined;
 
   const envVars = checkForRequired(["WEATHER_LINK_API_KEY", "WEATHER_LINK_API_SECRET", "WEATHER_LINK_BASE_API_URL"])
   if (!envVars.exist) {
@@ -18,13 +18,17 @@ export default (options) => {
 
   const API_KEY = process.env.WEATHER_LINK_API_KEY;
 
-  axios.get(
-    buildWeatherLinkApiUrl(
-      'stations',
-      { "api-key": API_KEY, "t": String(Math.round(Date.now() / 1000)) },
-      { "api-key": API_KEY, "t": String(Math.round(Date.now() / 1000)) }
-    )
-  )
+  const urlToQuery = buildWeatherLinkApiUrl(
+    'stations',
+    { "api-key": API_KEY, "t": String(Math.round(Date.now() / 1000)) },
+    { "api-key": API_KEY, "t": String(Math.round(Date.now() / 1000)) }
+  );
+
+  if (options.dryRun) {
+    return console.log(urlToQuery);
+  }
+
+  axios.get(urlToQuery)
     .then((response) => {
 
       if (options.raw) {

--- a/commands/metadata/stations.js
+++ b/commands/metadata/stations.js
@@ -5,7 +5,7 @@ import ora from 'ora';
 import { buildWeatherLinkApiUrl, checkForRequired } from '../../lib/utils.js';
 
 export default (stationIds, options) => {
-  const spinner = !options.raw ? ora('Searching for Stations').start() : undefined;
+  const spinner = !options.raw && !options.dryRun ? ora('Searching for Stations').start() : undefined;
 
   const envVars = checkForRequired(["WEATHER_LINK_API_KEY", "WEATHER_LINK_API_SECRET", "WEATHER_LINK_BASE_API_URL"])
   if (!envVars.exist) {
@@ -18,13 +18,17 @@ export default (stationIds, options) => {
 
   const API_KEY = process.env.WEATHER_LINK_API_KEY;
 
-  axios.get(
-    buildWeatherLinkApiUrl(
-      `stations/${stationIds}`,
-      { "api-key": API_KEY, "station-ids": String(stationIds), "t": String(Math.round(Date.now() / 1000)) },
-      { "api-key": API_KEY, "t": String(Math.round(Date.now() / 1000)) }
-    )
-  )
+  const urlToQuery = buildWeatherLinkApiUrl(
+    `stations/${stationIds}`,
+    { "api-key": API_KEY, "station-ids": String(stationIds), "t": String(Math.round(Date.now() / 1000)) },
+    { "api-key": API_KEY, "t": String(Math.round(Date.now() / 1000)) }
+  );
+
+  if (options.dryRun) {
+    return console.log(urlToQuery);
+  }
+
+  axios.get(urlToQuery)
     .then((response) => {
       if (options.raw) {
         return console.log(JSON.stringify(response.data));

--- a/commands/weather/current.js
+++ b/commands/weather/current.js
@@ -5,7 +5,7 @@ import ora from 'ora';
 import { buildWeatherLinkApiUrl, checkForRequired } from '../../lib/utils.js';
 
 export default (stationId, options) => {
-  const spinner = !options.raw ? ora('Retrieving Current Weather Data').start() : undefined;
+  const spinner = !options.raw && !options.dryRun ? ora('Retrieving Current Weather Data').start() : undefined;
 
   const envVars = checkForRequired(["WEATHER_LINK_API_KEY", "WEATHER_LINK_API_SECRET", "WEATHER_LINK_BASE_API_URL"])
   if (!envVars.exist) {
@@ -18,13 +18,17 @@ export default (stationId, options) => {
 
   const API_KEY = process.env.WEATHER_LINK_API_KEY;
 
-  axios.get(
-    buildWeatherLinkApiUrl(
-      `current/${stationId}`,
-      { "api-key": API_KEY, "station-id": String(stationId), "t": String(Math.round(Date.now() / 1000)) },
-      { "api-key": API_KEY, "t": String(Math.round(Date.now() / 1000)) }
-    )
-  )
+  const urlToQuery = buildWeatherLinkApiUrl(
+    `current/${stationId}`,
+    { "api-key": API_KEY, "station-id": String(stationId), "t": String(Math.round(Date.now() / 1000)) },
+    { "api-key": API_KEY, "t": String(Math.round(Date.now() / 1000)) }
+  );
+
+  if (options.dryRun) {
+    return console.log(urlToQuery);
+  }
+
+  axios.get(urlToQuery)
     .then((response) => {
       if (options.raw) {
         return console.log(JSON.stringify(response.data));

--- a/index.js
+++ b/index.js
@@ -26,17 +26,20 @@ const metadata = program.command("metadata")
 
 metadata.command("catalog")
   .description("Get a catalog of all available sensor types and the data reported by each sensor.")
+  .option("-d, --dry-run", "Checks for the necessary environmental variables and outputs the URL that would be queried.")
   .option("-r, --raw", "Display the raw response from the WeatherLink API.")
   .action(catalog);
 
 metadata.command("mine")
   .description("Returns an array of Weather Station Id(s) that are associated with your WeatherLink API Key.")
+  .option("-d, --dry-run", "Checks for the necessary environmental variables and outputs the URL that would be queried.")
   .option("-r, --raw", "Display the raw response from the WeatherLink API.")
   .action(mine);
 
 metadata.command("stations")
   .description("Returns all available information about 1 or more weather stations associated with your WeatherLink API Key.")
   .argument('<station-ids>', 'A comma-separated list of Weather Station Id(s) that you want information about.')
+  .option("-d, --dry-run", "Checks for the necessary environmental variables and outputs the URL that would be queried.")
   .option("-r, --raw", "Display the raw response from the WeatherLink API.")
   .action(stations);
 
@@ -46,6 +49,7 @@ const weather = program.command("weather")
 weather.command("current")
   .description("Get the current weather data for 1 weather station associated with your WeatherLink API Key.")
   .argument('<station-id>', 'The Station ID of the weather station that you want current weather data for.')
+  .option("-d, --dry-run", "Checks for the necessary environmental variables and outputs the URL that would be queried.")
   .option("-r, --raw", "Display the raw response from the WeatherLink API.")
   .action(current);
 
@@ -54,6 +58,7 @@ weather.command("historic")
   .argument('<station-id>', 'The Station ID of the weather station that you want current weather data for.')
   .argument('<start-timestamp>', 'A Unix timestamp marking the beginning of the historical period (must be earlier than end-timestamp but not more than 24 hours earlier).')
   .argument('<end-timestamp>', 'A Unix timestamp marking the end of the historical period (must be later than start-timestamp but not more than 24 hours later).')
+  .option("-d, --dry-run", "Checks for the necessary environmental variables and outputs the URL that would be queried.")
   .option("-r, --raw", "Display the raw response from the WeatherLink API.")
   .action(historic);
 


### PR DESCRIPTION
This PR adds a new dry run (`--dry-run` or `-d`) option flag to all of the `metadata` and `weather` subcommands. 

The dry run flag is designed to allow users of `wlbot` to check that they have all of the required environmental variables for that command set in their environment **and** see the full URL that would have been queried if it wasn't a dry run.