### PR TITLE
Update Target Branch of `dependabot` Scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    target-branch: "development"
+    target-branch: "main"
     labels:
       - "dependencies"


### PR DESCRIPTION
Related to: #15 

This PR corrects the `target-branch` from `development` to `main` with the new simplified branch structure for this repo.