### PR TITLE
Enable Github Action to Run Basic CI Tests

### DIFF
--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -10,9 +10,7 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v4
-
       - name: Install Dependencies
-      - run: npm ci
-      
+        run: npm ci
       - name: Execute Tests
-      - run: npm test
+        run: npm test

--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -1,0 +1,14 @@
+name: wlbot CI Testing
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run wlbot CI Testing
+        uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm test

--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -1,4 +1,4 @@
-name: wlbot CI Testing
+name: Regression Testing
 
 on:
   pull_request:
@@ -8,7 +8,11 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - name: Run wlbot CI Testing
+      - name: Checkout Branch
         uses: actions/checkout@v4
+
+      - name: Install Dependencies
       - run: npm ci
+      
+      - name: Execute Tests
       - run: npm test


### PR DESCRIPTION
This PR adds a Github Action that will run on all PRs that target the `main` branch to run the current basic CI tests. I plan to expand this testing in the near future.