### PR TITLE
Update Dependabot Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    target-branch: "main"
     directory: "/"
     schedule:
-      interval: "daily"
-    target-branch: "main"
+      interval: "weekly"
+    assignees:
+      - "mike-weiner"
     labels:
       - "dependencies"


### PR DESCRIPTION
This PR contains some updates to the dependabot config:

- Only check for updates on a weekly basis - daily was too frequent. 
- Assign all of the PRs opened by dependabot to `mike-weiner`.