### PR TITLE
Update `README` to Reflect New UT Requirement & Set Minimum Thresholds

### DIFF
--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -53,14 +53,13 @@ jobs:
       - name: Run Tests & Generate Coverage
         run: npm test
 
-      #  Compares two code coverage files and generates report as a comment
       - name: Generate Code Coverage Report
         id: code-coverage
         uses: barecheck/code-coverage-action@v1
         with:
-          barecheck-github-app-token: ${{ secrets.BARECHECK_GITHUB_APP_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           lcov-file: "./coverage/lcov.info"
           base-lcov-file: "./lcov.info"
           send-summary-comment: true
-          show-annotations: "warning" # Possible options warning|error
+          show-annotations: "warning"
             

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ First, search open issues to see if a ticket has already been created for the is
 
 **All contributions should be developed in a `feature/` branch off of the `development` branch as a PR will be required before any changes are merged back into the `development` branch.**
 
-If you are introducing new functionality, please add unit tests (UTs) to test the functionality of your contribution. All unit tests should be able to run locally. You will need to install the `devDependencies` to run the UTs.
+If you are introducing new functionality, please add unit tests (UTs) to test your contribution. All unit tests should be able to run locally. You will need to install the `devDependencies` to run the UTs.
 
 ## License
 Distributed under the MIT License. See `LICENSE.txt` for more information.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ First, search open issues to see if a ticket has already been created for the is
 
 **All contributions should be developed in a `feature/` branch off of the `development` branch as a PR will be required before any changes are merged back into the `development` branch.**
 
-If you are introducing new functionality, please add unit tests (UTs) to test your contribution. All unit tests should be able to run locally. You will need to install the `devDependencies` to run the UTs.
+If you are introducing new functionality, please add unit tests (UTs) to ensure the functionality of your contribution and its backwards compatibility. All UTs should be able to run locally. You will need to install the `devDependencies` to run the UTs.
 
 ## License
 Distributed under the MIT License. See `LICENSE.txt` for more information.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ First, search open issues to see if a ticket has already been created for the is
 
 **All contributions should be developed in a `feature/` branch off of the `development` branch as a PR will be required before any changes are merged back into the `development` branch.**
 
+If you are introducing new functionality, please add unit tests (UTs) to test the functionality of your contribution. All unit tests should be able to run locally. You will need to install the `devDependencies` to run the UTs.
+
 ## License
 Distributed under the MIT License. See `LICENSE.txt` for more information.
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,12 @@
 export default {
+  coverageThreshold: {
+    global: {
+      branches: 95,
+      functions: 95,
+      lines: 95,
+      statements: -30,
+    },
+  },
   collectCoverageFrom: [
     '**/*.{js,jsx}',
     '!**/node_modules/**',


### PR DESCRIPTION
This PR:

- Updates the `README` to explain the new unit testing policy.
- Moves the CI & Coverage PR action to the GitHub App.
- Sets the global minimum thresholds for code coverage in the `jest` config so it will fail if we fall below those thresholds.