### PR TITLE
Separate `wlbot status` Logic

### DIFF
--- a/commands/status.js
+++ b/commands/status.js
@@ -14,6 +14,10 @@ export default async function (service, _) {
   try {
     const response = await axios.get('https://0886445102835570.hostedstatus.com/1.0/status/600712dea9c1290530967bc6');
 
+    if (!Array.isArray(response.data.result.status)) {
+      throw ({ response: { data: { message: 'Hosted Status returned in an unexpected format.' }, status: 999 } })
+    }
+
     var requestedDavisServices = service === 'all' ?
       response.data.result.status
       :
@@ -21,9 +25,15 @@ export default async function (service, _) {
         return davisService.name === fullServiceName[service];
       });
 
+    requestedDavisServices.forEach((requestedService) => {
+      console.log(requestedService.name + ' is ' + requestedService.status + ' (Status Code: ' + requestedService.status_code + ')');
+    });
+
     return requestedDavisServices;
 
   } catch (error) {
+    console.log('Error: ' + error);
+
     return ({
       'error': {
         'msg': `${error.response.data.message}`,

--- a/index.js
+++ b/index.js
@@ -70,17 +70,7 @@ program.command("config")
 program.command("status")
   .description("Retrieves the operational status(es) of Davis Instrument's services.")
   .addArgument(new Argument('[service]', 'The Davis Instrument service that you want to obtain the operational status of.').choices(['all', 'api', 'dataingest', 'mobile', 'syscomms', 'website']).default('all'))
-  .action((service, options) => {
-    status(service, options).then((result) => {
-      if (!Array.isArray(result)) {
-        console.log('Error: ' + result.error.msg);
-      } else {
-        result.forEach((requestedService) => {
-          console.log(requestedService.name + ' is ' + requestedService.status + ' (Status Code: ' + requestedService.status_code + ')');
-        });
-      }
-    });
-  });
+  .action(status);
 
 program.commands.sort((a, b) => a._name.localeCompare(b._name));
 program.parse(process.argv);


### PR DESCRIPTION
Closes: #26 

This PR moves the underlying back-end logic for the `wlbot status` command into the existing `commands/status.js` file.