### PR TITLE
Reorganize Unit Test Files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,7 @@ jest.config.js
 .jest/
 coverage/
 node_modules/
-**/__tests__
+tests/
 
 # Ignore Github Repo Configuration
 .github/

--- a/tests/commands/config.test.js
+++ b/tests/commands/config.test.js
@@ -9,7 +9,7 @@ jest.unstable_mockModule('ora', () => ({
   })
 }));
 
-const { default: config } = await import('../config.js');
+const { default: config } = await import('../../commands/config.js');
 
 describe('wlbot config', () => {
 

--- a/tests/commands/metadata/catalong.test.js
+++ b/tests/commands/metadata/catalong.test.js
@@ -25,12 +25,12 @@ jest.unstable_mockModule('../../../lib/utils.js', () => {
   };
 });
 
-const { default: stations } = await import('../stations.js');
+const { default: catalog } = await import('../../../commands/metadata/catalog.js');
 
 const logSpy = jest.spyOn(console, "log").mockImplementation(() => { });
 const dirSpy = jest.spyOn(console, "dir").mockImplementation(() => { });
 
-describe('wlbot metadata stations', () => {
+describe('wlbot metadata catalog', () => {
 
   beforeEach(() => {
     jest.resetModules();
@@ -42,8 +42,7 @@ describe('wlbot metadata stations', () => {
 
   const mockSuccessfulApiCall = {
     data: {
-      stations: [1],
-      unit: "test",
+      unit: "test"
     },
   }
 
@@ -60,7 +59,7 @@ describe('wlbot metadata stations', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await stations(1, { dryRun: true, });
+    await catalog({ dryRun: true, });
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
@@ -78,7 +77,7 @@ describe('wlbot metadata stations', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await expect(stations(1, {})).resolves.toBe(mockSuccessfulApiCall);
+    await expect(catalog({})).resolves.toBe(mockSuccessfulApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
@@ -97,7 +96,7 @@ describe('wlbot metadata stations', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await expect(stations(1, { raw: true })).resolves.toBe(mockSuccessfulApiCall);
+    await expect(catalog({ raw: true })).resolves.toBe(mockSuccessfulApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
@@ -116,7 +115,7 @@ describe('wlbot metadata stations', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await expect(stations(1, {})).rejects.toEqual(mockFailedApiCall);
+    await expect(catalog({})).rejects.toEqual(mockFailedApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
@@ -135,7 +134,7 @@ describe('wlbot metadata stations', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await expect(stations(1, { raw: true, })).rejects.toEqual(mockFailedApiCall);
+    await expect(catalog({ raw: true, })).rejects.toEqual(mockFailedApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
@@ -152,7 +151,7 @@ describe('wlbot metadata stations', () => {
   it('Failure: Missing Environment Variables', async () => {
     checkForRequiredMock.mockReturnValue({ exist: false, missing: ['WEATHER_LINK_BASE_API_URL'] });
 
-    await stations(1, {});
+    await catalog({});
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);
@@ -169,7 +168,7 @@ describe('wlbot metadata stations', () => {
   it('Failure: Missing Environment Variables (No Spinner)', async () => {
     checkForRequiredMock.mockReturnValue({ exist: false, missing: ['WEATHER_LINK_BASE_API_URL'] });
 
-    await stations(1, { dryRun: true, raw: true });
+    await catalog({ dryRun: true, raw: true });
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);

--- a/tests/commands/metadata/mine.test.js
+++ b/tests/commands/metadata/mine.test.js
@@ -25,12 +25,12 @@ jest.unstable_mockModule('../../../lib/utils.js', () => {
   };
 });
 
-const { default: current } = await import('../current.js');
+const { default: mine } = await import('../../../commands/metadata/mine.js');
 
 const logSpy = jest.spyOn(console, "log").mockImplementation(() => { });
 const dirSpy = jest.spyOn(console, "dir").mockImplementation(() => { });
 
-describe('wlbot weather current', () => {
+describe('wlbot metadata mine', () => {
 
   beforeEach(() => {
     jest.resetModules();
@@ -42,7 +42,18 @@ describe('wlbot weather current', () => {
 
   const mockSuccessfulApiCall = {
     data: {
-      unit: "test"
+      stations: [
+        {
+          station_id: 1,
+        },
+        {
+          station_id: 2,
+        },
+        {
+          station_id: 3,
+        },
+      ],
+      unit: "test",
     },
   }
 
@@ -59,7 +70,7 @@ describe('wlbot weather current', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await current(12345, { dryRun: true, });
+    await mine({ dryRun: true, });
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
@@ -77,14 +88,14 @@ describe('wlbot weather current', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await expect(current(12345, {})).resolves.toBe(mockSuccessfulApiCall);
+    await expect(mine({})).resolves.toStrictEqual([1, 2, 3]);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
     expect(dirSpy).toHaveBeenCalledTimes(1);
-    expect(dirSpy).toHaveBeenCalledWith(mockSuccessfulApiCall.data, { depth: null });
+    expect(dirSpy).toHaveBeenCalledWith([1, 2, 3], { depth: null });
     expect(logSpy).toHaveBeenCalledTimes(0);
     expect(oraFailMock).toHaveBeenCalledTimes(0);
     expect(oraStartMock).toHaveBeenCalledTimes(1);
@@ -96,7 +107,7 @@ describe('wlbot weather current', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await expect(current(12345, { raw: true })).resolves.toBe(mockSuccessfulApiCall);
+    await expect(mine({ raw: true })).resolves.toBe(undefined);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
@@ -115,7 +126,7 @@ describe('wlbot weather current', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await expect(current(12345, {})).rejects.toEqual(mockFailedApiCall);
+    await expect(mine({})).rejects.toEqual(mockFailedApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
@@ -134,7 +145,7 @@ describe('wlbot weather current', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await expect(current(12345, { raw: true, })).rejects.toEqual(mockFailedApiCall);
+    await expect(mine({ raw: true, })).rejects.toEqual(mockFailedApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
@@ -151,7 +162,7 @@ describe('wlbot weather current', () => {
   it('Failure: Missing Environment Variables', async () => {
     checkForRequiredMock.mockReturnValue({ exist: false, missing: ['WEATHER_LINK_BASE_API_URL'] });
 
-    await current(12345, {});
+    await mine({});
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);
@@ -168,7 +179,7 @@ describe('wlbot weather current', () => {
   it('Failure: Missing Environment Variables (No Spinner)', async () => {
     checkForRequiredMock.mockReturnValue({ exist: false, missing: ['WEATHER_LINK_BASE_API_URL'] });
 
-    await current(12345, { dryRun: true, raw: true });
+    await mine({ dryRun: true, raw: true });
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);

--- a/tests/commands/metadata/stations.test.js
+++ b/tests/commands/metadata/stations.test.js
@@ -25,12 +25,12 @@ jest.unstable_mockModule('../../../lib/utils.js', () => {
   };
 });
 
-const { default: catalog } = await import('../catalog.js');
+const { default: stations } = await import('../../../commands/metadata/stations.js');
 
 const logSpy = jest.spyOn(console, "log").mockImplementation(() => { });
 const dirSpy = jest.spyOn(console, "dir").mockImplementation(() => { });
 
-describe('wlbot metadata catalog', () => {
+describe('wlbot metadata stations', () => {
 
   beforeEach(() => {
     jest.resetModules();
@@ -42,7 +42,8 @@ describe('wlbot metadata catalog', () => {
 
   const mockSuccessfulApiCall = {
     data: {
-      unit: "test"
+      stations: [1],
+      unit: "test",
     },
   }
 
@@ -59,7 +60,7 @@ describe('wlbot metadata catalog', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await catalog({ dryRun: true, });
+    await stations(1, { dryRun: true, });
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
@@ -77,7 +78,7 @@ describe('wlbot metadata catalog', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await expect(catalog({})).resolves.toBe(mockSuccessfulApiCall);
+    await expect(stations(1, {})).resolves.toBe(mockSuccessfulApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
@@ -96,7 +97,7 @@ describe('wlbot metadata catalog', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await expect(catalog({ raw: true })).resolves.toBe(mockSuccessfulApiCall);
+    await expect(stations(1, { raw: true })).resolves.toBe(mockSuccessfulApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
@@ -115,7 +116,7 @@ describe('wlbot metadata catalog', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await expect(catalog({})).rejects.toEqual(mockFailedApiCall);
+    await expect(stations(1, {})).rejects.toEqual(mockFailedApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
@@ -134,7 +135,7 @@ describe('wlbot metadata catalog', () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
 
-    await expect(catalog({ raw: true, })).rejects.toEqual(mockFailedApiCall);
+    await expect(stations(1, { raw: true, })).rejects.toEqual(mockFailedApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
@@ -151,7 +152,7 @@ describe('wlbot metadata catalog', () => {
   it('Failure: Missing Environment Variables', async () => {
     checkForRequiredMock.mockReturnValue({ exist: false, missing: ['WEATHER_LINK_BASE_API_URL'] });
 
-    await catalog({});
+    await stations(1, {});
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);
@@ -168,7 +169,7 @@ describe('wlbot metadata catalog', () => {
   it('Failure: Missing Environment Variables (No Spinner)', async () => {
     checkForRequiredMock.mockReturnValue({ exist: false, missing: ['WEATHER_LINK_BASE_API_URL'] });
 
-    await catalog({ dryRun: true, raw: true });
+    await stations(1, { dryRun: true, raw: true });
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);

--- a/tests/commands/status.test.js
+++ b/tests/commands/status.test.js
@@ -9,7 +9,7 @@ jest.unstable_mockModule('axios', () => ({
 
 const logSpy = jest.spyOn(console, "log").mockImplementation(() => { });
 
-const { default: status } = await import('../status.js');
+const { default: status } = await import('../../commands/status.js');
 
 describe('wlbot config', () => {
   const mockSuccessfulApiCall = {

--- a/tests/commands/weather/current.test.js
+++ b/tests/commands/weather/current.test.js
@@ -18,21 +18,19 @@ jest.unstable_mockModule('ora', () => ({
 
 const buildWeatherLinkApiUrlMock = jest.fn();
 const checkForRequiredMock = jest.fn();
-const dateRangeIsValidMock = jest.fn();
 jest.unstable_mockModule('../../../lib/utils.js', () => {
   return {
     buildWeatherLinkApiUrl: buildWeatherLinkApiUrlMock,
     checkForRequired: checkForRequiredMock,
-    dateRangeIsValid: dateRangeIsValidMock,
   };
 });
 
-const { default: historic } = await import('../historic.js');
+const { default: current } = await import('../../../commands/weather/current.js');
 
 const logSpy = jest.spyOn(console, "log").mockImplementation(() => { });
 const dirSpy = jest.spyOn(console, "dir").mockImplementation(() => { });
 
-describe('wlbot weather historic', () => {
+describe('wlbot weather current', () => {
 
   beforeEach(() => {
     jest.resetModules();
@@ -60,14 +58,12 @@ describe('wlbot weather historic', () => {
   it('Success: Dry Run to Display Query URL', async () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
-    dateRangeIsValidMock.mockReturnValue({ isValid: true, msg: "" });
 
-    await historic(12345, 0, 1, { dryRun: true });
+    await current(12345, { dryRun: true, });
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
-    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
     expect(dirSpy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith('http://unit.test');
@@ -80,15 +76,13 @@ describe('wlbot weather historic', () => {
     axiosGetMock.mockImplementationOnce(() => Promise.resolve(mockSuccessfulApiCall));
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
-    dateRangeIsValidMock.mockReturnValue({ isValid: true, msg: "" });
 
-    await expect(historic(12345, 0, 1, {})).resolves.toBe(mockSuccessfulApiCall);
+    await expect(current(12345, {})).resolves.toBe(mockSuccessfulApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
-    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
     expect(dirSpy).toHaveBeenCalledTimes(1);
     expect(dirSpy).toHaveBeenCalledWith(mockSuccessfulApiCall.data, { depth: null });
     expect(logSpy).toHaveBeenCalledTimes(0);
@@ -101,57 +95,16 @@ describe('wlbot weather historic', () => {
     axiosGetMock.mockImplementationOnce(() => Promise.resolve(mockSuccessfulApiCall));
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
-    dateRangeIsValidMock.mockReturnValue({ isValid: true, msg: "" });
 
-    await expect(historic(12345, 0, 1, { raw: true })).resolves.toBe(mockSuccessfulApiCall);
+    await expect(current(12345, { raw: true })).resolves.toBe(mockSuccessfulApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
-    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
     expect(dirSpy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockSuccessfulApiCall.data));
-    expect(oraFailMock).toHaveBeenCalledTimes(0);
-    expect(oraStartMock).toHaveBeenCalledTimes(0);
-    expect(oraSucceedMock).toHaveBeenCalledTimes(0);
-  });
-
-  it('Failure: Date Range is Invalid', () => {
-    buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
-    checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
-    dateRangeIsValidMock.mockReturnValue({ isValid: false, msg: "Invalid datetime range." });
-
-    expect(historic(12345, -1, 0, {}));
-
-    expect(axiosGetMock).toHaveBeenCalledTimes(0);
-    expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);
-    expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
-    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
-    expect(dirSpy).toHaveBeenCalledTimes(0);
-    expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid datetime range.'));
-    expect(oraFailMock).toHaveBeenCalledTimes(1);
-    expect(oraFailMock).toHaveBeenCalledWith(expect.stringContaining('Invalid datetime range.'));
-    expect(oraStartMock).toHaveBeenCalledTimes(1);
-    expect(oraSucceedMock).toHaveBeenCalledTimes(0);
-  });
-
-  it('Failure: Date Range is Invalid (No Spinner)', () => {
-    buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
-    checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
-    dateRangeIsValidMock.mockReturnValue({ isValid: false, msg: "Invalid datetime range." });
-
-    expect(historic(12345, -1, 0, { raw: true }));
-
-    expect(axiosGetMock).toHaveBeenCalledTimes(0);
-    expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);
-    expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
-    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
-    expect(dirSpy).toHaveBeenCalledTimes(0);
-    expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid datetime range.'));
     expect(oraFailMock).toHaveBeenCalledTimes(0);
     expect(oraStartMock).toHaveBeenCalledTimes(0);
     expect(oraSucceedMock).toHaveBeenCalledTimes(0);
@@ -161,15 +114,13 @@ describe('wlbot weather historic', () => {
     axiosGetMock.mockImplementationOnce(() => Promise.reject(mockFailedApiCall));
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
-    dateRangeIsValidMock.mockReturnValue({ isValid: true, msg: "" });
 
-    await expect(historic(12345, 0, 1, {})).rejects.toEqual(mockFailedApiCall);
+    await expect(current(12345, {})).rejects.toEqual(mockFailedApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
-    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
     expect(dirSpy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Error'));
@@ -182,15 +133,13 @@ describe('wlbot weather historic', () => {
     axiosGetMock.mockImplementationOnce(() => Promise.reject(mockFailedApiCall));
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
-    dateRangeIsValidMock.mockReturnValue({ isValid: true, msg: "" });
 
-    await expect(historic(12345, 0, 1, { raw: true, })).rejects.toEqual(mockFailedApiCall);
+    await expect(current(12345, { raw: true, })).rejects.toEqual(mockFailedApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
-    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
     expect(dirSpy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockFailedApiCall.response.data));
@@ -202,12 +151,11 @@ describe('wlbot weather historic', () => {
   it('Failure: Missing Environment Variables', async () => {
     checkForRequiredMock.mockReturnValue({ exist: false, missing: ['WEATHER_LINK_BASE_API_URL'] });
 
-    await historic(12345, 0, 1, {});
+    await current(12345, {});
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
-    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(0);
     expect(dirSpy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Missing Environment Variable'));
@@ -220,12 +168,11 @@ describe('wlbot weather historic', () => {
   it('Failure: Missing Environment Variables (No Spinner)', async () => {
     checkForRequiredMock.mockReturnValue({ exist: false, missing: ['WEATHER_LINK_BASE_API_URL'] });
 
-    await historic(12345, 0, 1, { dryRun: true, raw: true });
+    await current(12345, { dryRun: true, raw: true });
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
-    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(0);
     expect(dirSpy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Missing Environment Variable'));

--- a/tests/commands/weather/historic.test.js
+++ b/tests/commands/weather/historic.test.js
@@ -18,19 +18,21 @@ jest.unstable_mockModule('ora', () => ({
 
 const buildWeatherLinkApiUrlMock = jest.fn();
 const checkForRequiredMock = jest.fn();
+const dateRangeIsValidMock = jest.fn();
 jest.unstable_mockModule('../../../lib/utils.js', () => {
   return {
     buildWeatherLinkApiUrl: buildWeatherLinkApiUrlMock,
     checkForRequired: checkForRequiredMock,
+    dateRangeIsValid: dateRangeIsValidMock,
   };
 });
 
-const { default: mine } = await import('../mine.js');
+const { default: historic } = await import('../../../commands/weather/historic.js');
 
 const logSpy = jest.spyOn(console, "log").mockImplementation(() => { });
 const dirSpy = jest.spyOn(console, "dir").mockImplementation(() => { });
 
-describe('wlbot metadata mine', () => {
+describe('wlbot weather historic', () => {
 
   beforeEach(() => {
     jest.resetModules();
@@ -42,18 +44,7 @@ describe('wlbot metadata mine', () => {
 
   const mockSuccessfulApiCall = {
     data: {
-      stations: [
-        {
-          station_id: 1,
-        },
-        {
-          station_id: 2,
-        },
-        {
-          station_id: 3,
-        },
-      ],
-      unit: "test",
+      unit: "test"
     },
   }
 
@@ -69,12 +60,14 @@ describe('wlbot metadata mine', () => {
   it('Success: Dry Run to Display Query URL', async () => {
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
+    dateRangeIsValidMock.mockReturnValue({ isValid: true, msg: "" });
 
-    await mine({ dryRun: true, });
+    await historic(12345, 0, 1, { dryRun: true });
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
+    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
     expect(dirSpy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith('http://unit.test');
@@ -87,15 +80,17 @@ describe('wlbot metadata mine', () => {
     axiosGetMock.mockImplementationOnce(() => Promise.resolve(mockSuccessfulApiCall));
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
+    dateRangeIsValidMock.mockReturnValue({ isValid: true, msg: "" });
 
-    await expect(mine({})).resolves.toStrictEqual([1, 2, 3]);
+    await expect(historic(12345, 0, 1, {})).resolves.toBe(mockSuccessfulApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
+    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
     expect(dirSpy).toHaveBeenCalledTimes(1);
-    expect(dirSpy).toHaveBeenCalledWith([1, 2, 3], { depth: null });
+    expect(dirSpy).toHaveBeenCalledWith(mockSuccessfulApiCall.data, { depth: null });
     expect(logSpy).toHaveBeenCalledTimes(0);
     expect(oraFailMock).toHaveBeenCalledTimes(0);
     expect(oraStartMock).toHaveBeenCalledTimes(1);
@@ -106,16 +101,57 @@ describe('wlbot metadata mine', () => {
     axiosGetMock.mockImplementationOnce(() => Promise.resolve(mockSuccessfulApiCall));
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
+    dateRangeIsValidMock.mockReturnValue({ isValid: true, msg: "" });
 
-    await expect(mine({ raw: true })).resolves.toBe(undefined);
+    await expect(historic(12345, 0, 1, { raw: true })).resolves.toBe(mockSuccessfulApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
+    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
     expect(dirSpy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockSuccessfulApiCall.data));
+    expect(oraFailMock).toHaveBeenCalledTimes(0);
+    expect(oraStartMock).toHaveBeenCalledTimes(0);
+    expect(oraSucceedMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('Failure: Date Range is Invalid', () => {
+    buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
+    checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
+    dateRangeIsValidMock.mockReturnValue({ isValid: false, msg: "Invalid datetime range." });
+
+    expect(historic(12345, -1, 0, {}));
+
+    expect(axiosGetMock).toHaveBeenCalledTimes(0);
+    expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);
+    expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
+    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
+    expect(dirSpy).toHaveBeenCalledTimes(0);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid datetime range.'));
+    expect(oraFailMock).toHaveBeenCalledTimes(1);
+    expect(oraFailMock).toHaveBeenCalledWith(expect.stringContaining('Invalid datetime range.'));
+    expect(oraStartMock).toHaveBeenCalledTimes(1);
+    expect(oraSucceedMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('Failure: Date Range is Invalid (No Spinner)', () => {
+    buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
+    checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
+    dateRangeIsValidMock.mockReturnValue({ isValid: false, msg: "Invalid datetime range." });
+
+    expect(historic(12345, -1, 0, { raw: true }));
+
+    expect(axiosGetMock).toHaveBeenCalledTimes(0);
+    expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);
+    expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
+    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
+    expect(dirSpy).toHaveBeenCalledTimes(0);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid datetime range.'));
     expect(oraFailMock).toHaveBeenCalledTimes(0);
     expect(oraStartMock).toHaveBeenCalledTimes(0);
     expect(oraSucceedMock).toHaveBeenCalledTimes(0);
@@ -125,13 +161,15 @@ describe('wlbot metadata mine', () => {
     axiosGetMock.mockImplementationOnce(() => Promise.reject(mockFailedApiCall));
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
+    dateRangeIsValidMock.mockReturnValue({ isValid: true, msg: "" });
 
-    await expect(mine({})).rejects.toEqual(mockFailedApiCall);
+    await expect(historic(12345, 0, 1, {})).rejects.toEqual(mockFailedApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
+    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
     expect(dirSpy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Error'));
@@ -144,13 +182,15 @@ describe('wlbot metadata mine', () => {
     axiosGetMock.mockImplementationOnce(() => Promise.reject(mockFailedApiCall));
     buildWeatherLinkApiUrlMock.mockReturnValue('http://unit.test');
     checkForRequiredMock.mockReturnValue({ exist: true, missing: [] });
+    dateRangeIsValidMock.mockReturnValue({ isValid: true, msg: "" });
 
-    await expect(mine({ raw: true, })).rejects.toEqual(mockFailedApiCall);
+    await expect(historic(12345, 0, 1, { raw: true, })).rejects.toEqual(mockFailedApiCall);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
     expect(axiosGetMock).toHaveReturned();
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(1);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
+    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(1);
     expect(dirSpy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockFailedApiCall.response.data));
@@ -162,11 +202,12 @@ describe('wlbot metadata mine', () => {
   it('Failure: Missing Environment Variables', async () => {
     checkForRequiredMock.mockReturnValue({ exist: false, missing: ['WEATHER_LINK_BASE_API_URL'] });
 
-    await mine({});
+    await historic(12345, 0, 1, {});
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
+    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(0);
     expect(dirSpy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Missing Environment Variable'));
@@ -179,11 +220,12 @@ describe('wlbot metadata mine', () => {
   it('Failure: Missing Environment Variables (No Spinner)', async () => {
     checkForRequiredMock.mockReturnValue({ exist: false, missing: ['WEATHER_LINK_BASE_API_URL'] });
 
-    await mine({ dryRun: true, raw: true });
+    await historic(12345, 0, 1, { dryRun: true, raw: true });
 
     expect(axiosGetMock).toHaveBeenCalledTimes(0);
     expect(buildWeatherLinkApiUrlMock).toHaveBeenCalledTimes(0);
     expect(checkForRequiredMock).toHaveBeenCalledTimes(1);
+    expect(dateRangeIsValidMock).toHaveBeenCalledTimes(0);
     expect(dirSpy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Missing Environment Variable'));

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -1,4 +1,4 @@
-import { buildWeatherLinkApiUrl, checkForRequired, dateRangeIsValid } from '../utils.js';
+import { buildWeatherLinkApiUrl, checkForRequired, dateRangeIsValid } from '../../lib/utils.js';
 
 describe('buildWeatherLinkApiUrl(...)', () => {
   describe('Correctly Builds WeatherLink API URL', () => {


### PR DESCRIPTION
Closes: #28.

This PR restructures the package's test files. All tests will now be houses under `tests/`. The `.npmignore` file was also updated to ignore this new directory during the packaging of `wlbot`. 