### PR TITLE
Prep for Release of `v1.1.6`

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const program = new Command();
 program
   .description("A CLI for the WeatherLink Live API.")
   .name("wlbot")
-  .version('1.1.5')
+  .version('1.1.6')
   .usage('<command>');
 
 const metadata = program.command("metadata")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wlbot",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wlbot",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wlbot",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "A CLI for the WeatherLink Live API.",
   "keywords": [
     "Davis Instruments",


### PR DESCRIPTION
With it being the first week of the month, let's cut a new release of `wlbot`. 

# `v1.1.6` Change Notes

This month's release of `weatherlinkbot` (`wlbot`) is a minor, non-breaking release.

## Fixes

- [Bump @babel/preset-env from 7.23.9 to 7.24.0](https://github.com/mike-weiner/wlbot/pull/37)

**Full Changelog**: https://github.com/mike-weiner/wlbot/compare/v1.1.5...v1.1.6