### PR TITLE
Prep Release of `v1.1.8`

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const program = new Command();
 program
   .description("A CLI for the WeatherLink Live API.")
   .name("wlbot")
-  .version('1.1.7')
+  .version('1.1.8')
   .usage('<command>');
 
 const metadata = program.command("metadata")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wlbot",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wlbot",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wlbot",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "A CLI for the WeatherLink Live API.",
   "keywords": [
     "Davis Instruments",


### PR DESCRIPTION
Related to: https://github.com/mike-weiner/wlbot/issues/45

With it being the first week of the month, let's cut a new release of `wlbot`. 

# `v1.1.8` Change Notes

This month's release of `weatherlinkbot` (`wlbot`) is a minor, non-breaking release.

## Dependency Updates

- [Bump @babel/preset-env from 7.24.3 to 7.24.4](https://github.com/mike-weiner/wlbot/pull/43)
- [Bump @babel/preset-env from 7.24.4 to 7.24.5](https://github.com/mike-weiner/wlbot/pull/44)

**Full Changelog**: https://github.com/mike-weiner/wlbot/compare/v1.1.7...v1.1.8