### PR TITLE
Bump GitHub CI Action to `upload-artifact@v4` and `download-artifact@v4`

### DIFF
--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -25,7 +25,7 @@ jobs:
         run: npm test
 
       - name: Upload Code Coverage for Bash Branch
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ref-lcov.info
           path: ./coverage/lcov.info
@@ -46,7 +46,7 @@ jobs:
           node-version: latest
 
       - name: Download Code Coverage Report from Base Branch
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ref-lcov.info
 


### PR DESCRIPTION
Related to: https://github.com/mike-weiner/wlbot/actions/runs/13094659127/job/36535464854?pr=91

While working to cut a new release of `wlbot`. CI began failing with: 

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

A quick Google search resulted in: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/