### PR TITLE
Fix: CI Jobs Should be Read-Only

### DIFF
--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   base_branch_coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/mike-weiner/wlbot/security/code-scanning/2](https://github.com/mike-weiner/wlbot/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `base_branch_coverage` job. Since this job only checks out the code, installs dependencies, runs tests, and uploads an artifact, it does not require any `write` permissions. The minimal required permission is `contents: read`. This change ensures that the job operates with the least privileges necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
