### PR TITLE
Fix GitHub Action to Bump Versions Pre-Release

### DIFF
--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -66,4 +66,3 @@ jobs:
             --body "This PR has been automatically created to bump the version of the CLI to $NEW_VERSION in preparation for an upcoming release." \
             --base "${{ github.event.repository.default_branch }}" \
             --head "release/$VERSION_STR" \
-            --draft


### PR DESCRIPTION
Related to: https://github.com/mike-weiner/wlbot/issues/135

This PR is a follow up to https://github.com/mike-weiner/wlbot/pull/136 for fixing a couple of bugs.
- Fix incorrect syntax for Linux based GitHub Action runners.
- Fix incorrect base branch name in PR creation logic.
- Don't create PRs in draft state.

The successful action run was here: https://github.com/mike-weiner/wlbot/actions/runs/16844595358. The PR it created was here: https://github.com/mike-weiner/wlbot/pull/137