### PR TITLE
Fix Node Version Typo in NPM Publish Automation

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Latest Node.js 
         uses: actions/setup-node@v4
         with:
-          node-version: Latest
+          node-version: latest
           registry-url: https://registry.npmjs.org/
 
       - name: Verify GH Release Tag Matches NPM Package Version


### PR DESCRIPTION
Related to: https://github.com/mike-weiner/wlbot/issues/134

This PR is a follow-up to #140. There was a small capitalization typo that broke the Github Action: https://github.com/mike-weiner/wlbot/actions/runs/16844920697