### PR TITLE
Update GitHub Actions Prior to Node 20 Deprecation

### DIFF
--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -11,12 +11,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.base_ref }}
       
       - name: Use Node.js Latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts' }}
 

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: ${{ github.base_ref }}
 
       - name: Install Latest Node.js 
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts' }}
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -29,12 +29,12 @@ jobs:
           esac
 
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install Latest Node.js 
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts' }}
 


### PR DESCRIPTION
Resolves https://github.com/mike-weiner/wlbot/issues/191.

This PR bumps both `actions/checkout` and `actions/setup-node` to `@v6` prior to the `@v4` Node 20 deprecation later this summer.